### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,7 @@ git submodule init webvirtbackend webvirtfrontend
 git submodule update
 ```
 
-4. Build the Docker image:
-```bash
-docker compose build
-```
-
-5. Run the Docker container with the production settings (ENV):
+4. Run the Docker container with the production settings (ENV):
 
 Create file `custom.env` add the next variables with your domain records. 
 
@@ -47,6 +42,11 @@ CONSOLE_DOMAIN=console.webvirt.local
 ```
 
 Check the `global.env` file for more information about the variables.
+
+5. Build the Docker image:
+```bash
+docker compose build
+```
 
 * If you want to use controller on your local machine you can use domain `webvirt.local` and you need add the next line to `/etc/hosts` file.
 


### PR DESCRIPTION
5 where 4 was and #4 where #5 was this is do to a user not being able to docker compose build without first adding a custom.env i.e steps need to be re-arranged for a smoother setup expierence.