### PR TITLE
Add docker compose and docker version detection

### DIFF
--- a/webvirtcloud.sh
+++ b/webvirtcloud.sh
@@ -102,11 +102,23 @@ help            Show this message
 EOF
 }
 
-# Check if docker installed
+# Check if Docker is installed
 if ! command -v docker &> /dev/null; then
-    echo -e "\nDocker not found! Please install docker first\n"
+    echo -e "\nDocker not found! Please install Docker first.\n"
     exit 1
 fi
+# Get Docker version
+docker_version=$(docker --version | grep -oP '\d+\.\d+\.\d+')
+# Define the required minimum version
+required_version="25.0.0"
+# Check if Docker version meets the requirement
+if [ "$docker_version" = "$(printf '%s\n' "$docker_version" "$required_version" | sort -V | head -n1)" ]; then
+    echo -e "\nDocker version $docker_version is sufficient.\n"
+else
+    echo -e "\nDocker version $docker_version is not sufficient. Please update Docker to version $required_version or later.\n"
+    exit 1
+fi
+# Check if Docker Compose is installed
 if docker compose version >/dev/null 2>&1; then
     DOCKER_COMPOSE_COMMAND="docker compose"
 elif command -v docker-compose >/dev/null 2>&1; then

--- a/webvirtcloud.sh
+++ b/webvirtcloud.sh
@@ -30,12 +30,12 @@ function start_webvirtcloud() {
     if [ ! -d ".mysql" ]; then
         ININT_DB=true
     fi
-
+    
     echo "Building WebVirtCloud..."
-    docker compose build backend --no-cache
+    $DOCKER_COMPOSE_COMMAND build backend --no-cache
     
     echo "Start WebVirtCloud..."
-    docker compose up -d
+    $DOCKER_COMPOSE_COMMAND up -d
     
     # Init database
     if [ "$ININT_DB" = true ]; then
@@ -46,7 +46,7 @@ function start_webvirtcloud() {
 # Load initial data
 function load_initial_data() {
     echo "Loading initial data..."
-    docker compose exec backend python manage.py loaddata initial_data
+    $DOCKER_COMPOSE_COMMAND exec backend python manage.py loaddata initial_data
 }
 
 # Init and update submodules
@@ -58,13 +58,13 @@ function init_submodules() {
 # Restart docker compose
 function restart_webvirtcloud() {
     echo "Restarting WebVirtCloud..."
-    docker compose restart
+    $DOCKER_COMPOSE_COMMAND restart
 }
 
 # Stop docker compose
 function stop_webvirtcloud() {
     echo "Stop WebVirtCloud..."
-    docker compose down
+    $DOCKER_COMPOSE_COMMAND down
 }
 
 # Pull latest changes
@@ -105,6 +105,14 @@ EOF
 # Check if docker installed
 if ! command -v docker &> /dev/null; then
     echo -e "\nDocker not found! Please install docker first\n"
+    exit 1
+fi
+if docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE_COMMAND="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE_COMMAND="docker-compose"
+else
+    echo "Neither 'docker compose' nor 'docker-compose' command found."
     exit 1
 fi
 


### PR DESCRIPTION
Due to this problem:
```
root@spiritlhl:~/webvirtcloud# ./webvirtcloud.sh start
 __        __   _  __     ___      _    ____ _                 _ 
 \ \      / ___| |_\ \   / (_)_ __| |_ / ___| | ___  _   _  __| |
  \ \ /\ / / _ | '_ \ \ / /| | '__| __| |   | |/ _ \| | | |/ _` |
   \ V  V |  __| |_) \ V / | | |  | |_| |___| | (_) | |_| | (_| |
    \_/\_/ \___|_.__/ \_/  |_|_|   \__|\____|_|\___/ \__,_|\__,_|
                                                                        
Building WebVirtCloud...
[+] Building 9.9s (13/13) FINISHED                                                                                                                          docker:default
 => [backend internal] load build definition from Dockerfile.backend                                                                                                  0.0s
 => => transferring dockerfile: 1.40kB                                                                                                                                0.0s
 => [backend internal] load .dockerignore                                                                                                                             0.0s
 => => transferring context: 109B                                                                                                                                     0.0s
 => [backend internal] load metadata for docker.io/library/python:3.10-alpine                                                                                         0.8s
 => CACHED [backend backend-deps 1/6] FROM docker.io/library/python:3.10-alpine@sha256:7e73eab259b777c76ad93e42180d468f326eff315c212bc80d4dffdf4695163a               0.0s
 => [backend internal] load build context                                                                                                                             0.0s
 => => transferring context: 27.15kB                                                                                                                                  0.0s
 => [backend backend-deps 2/6] RUN apk add --no-cache gcc g++ pango fontconfig ttf-freefont font-noto terminus-font                        musl-dev mariadb-dev libf  3.9s
 => [backend backend-deps 3/6] WORKDIR /requirements                                                                                                                  0.0s 
 => [backend backend-deps 4/6] COPY ./webvirtbackend/requirements/production.txt /requirements/requirements.txt                                                       0.0s 
 => [backend backend-deps 5/6] COPY ./optional-requirements.txt* /requirements/                                                                                       0.0s 
 => [backend backend-deps 6/6] RUN pip install -U uv;     uv pip install --system -r requirements.txt;     if [ -e optional-requirements.txt ]; then     uv pip inst  4.0s 
 => [backend backend 1/2] WORKDIR /backend                                                                                                                            0.0s 
 => [backend backend 2/2] COPY ./webvirtbackend/ /backend/                                                                                                            0.0s 
 => [backend] exporting to image                                                                                                                                      1.1s 
 => => exporting layers                                                                                                                                               1.1s 
 => => writing image sha256:0393f785a77ffcec6ce04e908bdbb062e3b0656a5b82627c5c9741214e09f367                                                                          0.0s 
 => => naming to docker.io/library/webvirtcloud:backend                                                                                                               0.0s 
Start WebVirtCloud...
[+] Running 0/0
 ⠋ Container webvirtcloud-frontend  Creating                                                                                                                          0.0s 
 ⠋ Container webvirtcloud-rabbitmq  Creating                                                                                                                          0.0s 
 ⠋ Container webvirtcloud-mariadb   Creating                                                                                                                          0.0s 
can't set healthcheck.start_interval as feature require Docker Engine v25 or later
```
I fixed it.